### PR TITLE
fix: compile error on ESP crosstool-NG (gcc version 14.2.0)

### DIFF
--- a/src/GDXLib.cpp
+++ b/src/GDXLib.cpp
@@ -778,7 +778,7 @@ byte GDXLib::GDX_getDefaultSensor()
     if (testMask & defaultMask & availableMask) return i;//use the default channel
     testMask = testMask << 1;
   }
-  if (i == 32) return 1; //if this did not work, just return 1 as the default
+  return 1; //if this did not work, just return 1 as the default
 }
 
 //=============================================================================


### PR DESCRIPTION
This PR fixes the compiling error on ESP32S3 using platformIO env.
Error:
``` sh
.pio/libdeps/debug/GDXLib/src/GDXLib.cpp: In member function 'byte GDXLib::GDX_getDefaultSensor()':
.pio/libdeps/debug/GDXLib/src/GDXLib.cpp:782:1: error: control reaches end of non-void function [-Werror=return-type]
  782 | }
      | ^
cc1plus: some warnings being treated as errors
*** [.pio/build/debug/libea3/GDXLib/GDXLib.cpp.o] Error 1
```

PlatformIO Env:
``` ini
[env]
board = esp32-s3-devkitc-1
framework = arduino
platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip

board_build.arduino.upstream_packages = yes
board_build.arduino.memory_type = qio_opi
board_build.mcu = esp32s3
board_upload.flash_size = 16MB
board_build.partitions = default_16MB.csv
board_build.filesystem = littlefs

lib_deps =
    arduino-libraries/ArduinoBLE @ ^1.3.7
    https://github.com/VernierST/GDXLib
```

Toolchain info:
`toolchain-xtensa-esp-elf/bin/xtensa-esp-elf-g++ -v` 
```
Using built-in specs.
COLLECT_GCC=/Users/momeppkt/.platformio/packages/toolchain-xtensa-esp-elf/bin/xtensa-esp-elf-g++
COLLECT_LTO_WRAPPER=/Users/momeppkt/.platformio/packages/toolchain-xtensa-esp-elf/bin/../libexec/gcc/xtensa-esp-elf/14.2.0/lto-wrapper
Target: xtensa-esp-elf
Configured with: /builds/idf/crosstool-NG/.build/xtensa-esp-elf/src/gcc/configure --build=x86_64-build_pc-linux-gnu --host=aarch64-host_apple-darwin21.1 --target=xtensa-esp-elf --prefix=/builds/idf/crosstool-NG/builds/xtensa-esp-elf --exec_prefix=/builds/idf/crosstool-NG/builds/xtensa-esp-elf --with-local-prefix=/builds/idf/crosstool-NG/builds/xtensa-esp-elf/xtensa-esp-elf --with-sysroot=/builds/idf/crosstool-NG/builds/xtensa-esp-elf/xtensa-esp-elf --with-native-system-header-dir=/include --with-newlib --enable-threads=no --disable-shared --with-pkgversion='crosstool-NG esp-14.2.0_20241119' --disable-__cxa_atexit --enable-cxx-flags=-ffunction-sections --disable-libgomp --disable-libmudflap --disable-libmpx --disable-libssp --disable-libquadmath --disable-libquadmath-support --disable-libstdcxx-verbose --with-gmp=/builds/idf/crosstool-NG/.build/xtensa-esp-elf/buildtools/complibs-host --with-mpfr=/builds/idf/crosstool-NG/.build/xtensa-esp-elf/buildtools/complibs-host --with-mpc=/builds/idf/crosstool-NG/.build/xtensa-esp-elf/buildtools/complibs-host --with-isl=/builds/idf/crosstool-NG/.build/xtensa-esp-elf/buildtools/complibs-host --enable-lto --enable-target-optspace --without-long-double-128 --disable-nls --enable-multiarch --enable-languages=c,c++ --disable-libstdcxx-verbose --enable-threads=posix --enable-gcov-custom-rtio --enable-libstdcxx-time=yes
Thread model: posix
Supported LTO compression algorithms: zlib
gcc version 14.2.0 (crosstool-NG esp-14.2.0_20241119)
```

This fixed by remove unnecessary if statement as loop naturally exits when i reaches 32 and the function `GDX_getDefaultSensor()` must be returned at the end.